### PR TITLE
(1) Normalize attachment filename as JIRA seems to respond with server error on non-ASCII names and (2) Python 3 compatibility fixes

### DIFF
--- a/ask-jira.py
+++ b/ask-jira.py
@@ -94,7 +94,7 @@ def _get_command(argparser):
     return command
 
 def _list_local_commands():
-    sorted_globals = globals().items()
+    sorted_globals = list(globals().items())
     sorted_globals.sort()
     commands = [(var, obj.__doc__) for var, obj in sorted_globals
         if not var.startswith('_')

--- a/exportimportconfig-sample.py
+++ b/exportimportconfig-sample.py
@@ -1,10 +1,10 @@
 from collections import namedtuple
 
 JIRA2 = {
-    "server": "https://example.com/jira2/",
-    "user": "user2",
-    "password": "password2"
-    "project": "PROJECTKEY",
+    'server': 'https://example.com/jira2/',
+    'user': 'user2',
+    'password': 'password2',
+    'project': 'PROJECTKEY',
 }
 
 PRIORITY_MAP = {
@@ -43,21 +43,21 @@ TARGET_EPIC_NAME_FIELD_ID = 'customfield_10009'
 WithResolution = namedtuple('WithResolution', 'transition_name')
 
 RESOLUTION_MAP = {
-    "Fixed": "Fixed",
+    'Fixed': 'Fixed',
     "Won't Fix": "Won't Fix",
-    "Later": "Won't Fix'",
-    "Duplicate": "Duplicate",
-    "Incomplete": "Incomplete",
-    "Cannot Reproduce": "Cannot Reproduce",
-    "Fixed as is": "Fixed",
-    "Fixed with minor changes": "Fixed",
-    "Fixed with changes": "Fixed",
-    "Fixed quite differently": "Fixed",
-    "Released": "Done",
-    "Resolved": "Done",
-    "Verified": "Done",
-    "Unresolved": "Won't Fix",
-    "Done": "Done",
+    'Later': "Won't Fix",
+    'Duplicate': 'Duplicate',
+    'Incomplete': 'Incomplete',
+    'Cannot Reproduce': 'Cannot Reproduce',
+    'Fixed as is': 'Fixed',
+    'Fixed with minor changes': 'Fixed',
+    'Fixed with changes': 'Fixed',
+    'Fixed quite differently': 'Fixed',
+    'Released': 'Done',
+    'Resolved': 'Done',
+    'Verified': 'Done',
+    'Unresolved': "Won't Fix",
+    'Done': 'Done',
 }
 
 STATUS_TRANSITIONS = {

--- a/lib/export_import.py
+++ b/lib/export_import.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import unicodedata
 from io import BytesIO
@@ -121,7 +122,8 @@ def _add_attachments(issue, jira, attachments):
                     attachment=buf)
 
 def _normalize_filename(value):
-    return unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')
+    return unicodedata.normalize('NFKD', value).encode('ascii',
+            'ignore').decode('ascii')
 
 # -------------------------------------
 # TODO:

--- a/lib/export_import.py
+++ b/lib/export_import.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import unicodedata
 from io import BytesIO
 from jira.client import JIRA
 from jira.exceptions import JIRAError
@@ -115,8 +116,12 @@ def _add_attachments(issue, jira, attachments):
         with BytesIO() as buf:
             for chunk in attachment.iter_content():
                 buf.write(chunk)
-            jira.add_attachment(issue, filename=attachment.filename,
+            jira.add_attachment(issue,
+                    filename=_normalize_filename(attachment.filename),
                     attachment=buf)
+
+def _normalize_filename(value):
+    return unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')
 
 # -------------------------------------
 # TODO:

--- a/lib/workdays.py
+++ b/lib/workdays.py
@@ -1,7 +1,7 @@
 class WorkdaysFromSeconds(object):
     def __init__(self, seconds):
         self.seconds = seconds
-        self._hours = seconds / (60.0 * 60)
+        self._hours = seconds // (60.0 * 60)
         self._days, self._day_hours = divmod(self._hours, 8)
 
     def __sub__(self, other):


### PR DESCRIPTION
See https://answers.atlassian.com/questions/143915/answers/32979258/comments/46688444:

> The only issue I have is while adding the attatchment to the new Jira ticket. I always get an error 500 with an empty error text. Do you have any idea what could be the cause here?
> I have identified the issue: The script currently doesn't support special characters like ä or é for attachment file names.