### PR TITLE
Work log support

### DIFF
--- a/lib/export_import.py
+++ b/lib/export_import.py
@@ -49,7 +49,7 @@ def _make_new_issues(source_jira, target_jira, issues, conf, result, parent):
 
         if issue.fields.worklog:
             for worklog in issue.fields.worklog.worklogs:
-                target_jira.add_worklog(new_issue, worklog.timeSpent)
+                target_jira.add_worklog(new_issue, None, worklog.timeSpentSeconds)
 
         if issue.fields.comment.comments:
             _add_comments(new_issue, target_jira, issue.fields.comment.comments)


### PR DESCRIPTION
## Changes

- Set the spent time in seconds instead of JIRA format e.g. "2d 3h"


## Description
It is better to set the spent time in seconds instead of JIRA format e.g. "2d 3h", because both JIRA instances could have different set up. Real case in the migration I did is that the first JIRA had 7 hours working day and the second one - 8 hours. In this situation if we migrate "1d" work log it will be represented as "7h" in the first JIRA and "8h" in the second one, that's why it is better to use seconds.