### PR TITLE
Custom field mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The task needs special configuration in `exportimportconfig.py` (see sample in
 * `RESOLUTION_MAP`: map source JIRA resolutions to target resolutions, only used when a `WithResolution` transition is used in `STATUS_TRANSITIONS`
 * `ADD_COMMENT_TO_OLD_ISSUE`: if `True`, add comment to source JIRA issue that it was exported to new issue in target JIRA with issue link
 * `CUSTOM_FIELD`: a single custom field that you can set to a default value for all issues (set to `None` if not needed)
+* `CUSTOM_FIELD_MAP`: map source JIRA fields to target JIRA fields. This can also be used for system fields that are not mapped out of the box, such as 'environment'
 
 Note that epics and sub-tasks should be excluded from the source JIRA query as
 they are automatically imported via the parent task. The the recommended

--- a/exportimportconfig-sample.py
+++ b/exportimportconfig-sample.py
@@ -74,3 +74,13 @@ STATUS_TRANSITIONS = {
 ADD_COMMENT_TO_OLD_ISSUE = True
 
 CUSTOM_FIELD = ('customfield_11086', {'value': 'Custom value'})
+
+CUSTOM_FIELD_MAP = {
+        'environment': 'environment',
+        'customfield_10200': 'customfield_11320', # User Story
+        'customfield_10008': 'customfield_10004', # Story Points
+        'customfield_10010': 'customfield_11321', # Acceptance Criteria
+        'customfield_10401': 'customfield_11311', # Current Behavior
+        'customfield_10402': 'customfield_11312', # Expected Behavior
+}
+

--- a/lib/export_import.py
+++ b/lib/export_import.py
@@ -110,6 +110,12 @@ def _get_new_issue_fields(fields, conf):
             result[name] = {'name': name_map[value]}
     if conf.CUSTOM_FIELD:
         result[conf.CUSTOM_FIELD[0]] = conf.CUSTOM_FIELD[1]
+    if conf.CUSTOM_FIELD_MAP:
+        for sourcename in conf.CUSTOM_FIELD_MAP.keys():
+            targetname = conf.CUSTOM_FIELD_MAP[sourcename]
+            value = getattr(fields, sourcename, None)
+            if value:
+                result[targetname] = value
     return result
 
 _g_epic_map = {}


### PR DESCRIPTION
This pull request introduces a new configuration field CUSTOM_FIELD_MAP.
It allows for migration of custom fields or system fields which are not migrated by default.

ask-jira simply iterates over this map and converts the source field names to the target field names.

Example:
```
CUSTOM_FIELD_MAP = {
        'environment': 'environment',
        'customfield_10200': 'customfield_11320', # User Story
        'customfield_10008': 'customfield_10004', # Story Points
        'customfield_10010': 'customfield_11321', # Acceptance Criteria
        'customfield_10401': 'customfield_11311', # Current Behavior
        'customfield_10402': 'customfield_11312', # Expected Behavior
}
```

This will probably fix #16 
