### PR TITLE
Support separate transitions per issue type

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The task needs special configuration in `exportimportconfig.py` (see sample in
 * `SOURCE_EPIC_NAME_FIELD_ID`: ID of the epic field in source JIRA, find it by calling `fields`, look for *Epic Name*
 * `TARGET_EPIC_NAME_FIELD_ID`: ID of the epic field in **target** JIRA, find it by changing configuration to use target JIRA and calling `fields`, look for *Epic Name*
 * `STATUS_TRANSITIONS`: map of source JIRA statuses to list of workflow transition names in target JIRA that result in equivalent status, `None` for no transition
+* `STATUS_TRANSITIONS_ISSUETYPE`: issuetype specific map of source JIRA statuses to list of workflow transition names in target JIRA that result in equivalent status, `None` for no transition. If an issuetype is not in this list, the default `STATUS_TRANSITIONS` are used.
 * `RESOLUTION_MAP`: map source JIRA resolutions to target resolutions, only used when a `WithResolution` transition is used in `STATUS_TRANSITIONS`
 * `ADD_COMMENT_TO_OLD_ISSUE`: if `True`, add comment to source JIRA issue that it was exported to new issue in target JIRA with issue link
 * `CUSTOM_FIELD`: a single custom field that you can set to a default value for all issues (set to `None` if not needed)

--- a/exportimportconfig-sample.py
+++ b/exportimportconfig-sample.py
@@ -71,6 +71,21 @@ STATUS_TRANSITIONS = {
         WithResolution('Testing passed')),
 }
 
+STATUS_TRANSITIONS_ISSUETYPE = {
+    'Sub-task': {
+        'To Do': None,
+        'In Progress': ('In Progress',),
+        'Review': ('In Progress',),
+        'Done': ('Done',),
+    },
+    'Task': {
+        'To Do': None,
+        'In Progress': ('In Progress',),
+        'Review': ('In Progress',),
+        'Done': ('Done',),
+    }
+}
+
 ADD_COMMENT_TO_OLD_ISSUE = True
 
 CUSTOM_FIELD = ('customfield_11086', {'value': 'Custom value'})

--- a/lib/export_import.py
+++ b/lib/export_import.py
@@ -131,8 +131,20 @@ def _set_epic_link(new_issue, old_issue, conf, source_jira, target_jira):
     print('linked to epic', target_epic.key, '...', end=' ')
 
 def _set_status(new_issue, old_issue, conf, target_jira):
+    issue_type = new_issue.fields.issuetype.name
     status_name = old_issue.fields.status.name
-    transitions = conf.STATUS_TRANSITIONS[status_name]
+
+    transitions = None
+    transition_map = getattr(conf, "STATUS_TRANSITIONS_ISSUETYPE", None)
+    if transition_map:
+        if issue_type in transition_map:
+            transition_map = transition_map[issue_type]
+        else:
+            transition_map = None
+    if not transition_map:
+        transition_map = conf.STATUS_TRANSITIONS
+
+    transitions = transition_map[status_name]
     if not transitions:
         return
     for transition_name in transitions:


### PR DESCRIPTION
Depending on the project setup it might be possible to have different workflows assigned to different issue types.
This pull request adds the ability to define the transitions per issue type separately.

Example:
```
STATUS_TRANSITIONS_ISSUETYPE = {
    'Sub-task': {
        'To Do': None,
        'In Progress': ('In Progress',),
        'Review': ('In Progress',),
        'Done': ('Done',),
    },
    'Task': {
        'To Do': None,
        'In Progress': ('In Progress',),
        'Review': ('In Progress',),
        'Done': ('Done',),
    }
}
```
For all issue types that do not have a status transition map defined this way, it will default to the ones defined in STATUS_TRANSITIONS.
