### PR TITLE
Preserve Jira IDs from the source system in the target system when migrating

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,33 @@ Full example:
         AND issuetype not in subTaskIssueTypes()
         AND issuetype != Epic'
 
+### Preserve JIRA IDs
+Under certain circumstances it is possible to keep the JIRA IDs from the soruce system in the target system.
+The idea is that Jira always numbers issues consecutively and thus we need to make sure we add them to the system in the correct order.
+
+Please note the following limitations:
+* Issues in the source system need to be consecutively numbered starting with one. If there are any gaps, e.g. because an administrator deleted a ticket in between this **will not work**
+* You need to start with a fresh, clean target project. If there are already issues or there used to be issues which had been deleted, Jira will not start numbering with 1, so this **will not work**
+i
+* Stories need to have a higher ID than their linked Epic. If this is not the case, the script will warn you and you need to establish the reference manually after the import is complete
+* Sub-Tasks need to have a higher ID than their parent. If this is not the case, the program will create the Sub-Task as a regular Task and give you a warning. You need to manually convert and assign the Sub-Task after the import is complete
+* It makes sense to use the same project ID in the target and source system such that the IDs are really identical, but this is not mandatory
+
+If all this is given and allright, you need to add the following statements to your *exportimportconfig.py*
+
+    NO\_AUTO\_CREATE\_EPICS = True
+    NO\_AUTO\_CREATE\_SUBTASKS = True
+
+This prevents ask-jira from creating EPICs or Sub-Tasks as soon as it finds references to them.
+But don't worry, *EPIC links* and *Sub-task to Parent* references are still estabished in most cases (according to the limitations above)
+
+Now go ahead and start the export/import process.
+**Important:** Make sure your JQL comprises *all* issues in the project and the issues are *sorted by ther ID*
+
+For example like this:
+     ./ask-jira.py export_import_issues_for_jql 'project = PROJ ORDER BY key'
+
+
 ## Importing worklogs from Google Calendar
 
 The `import_worklogs_from_google_calendar` task helps filling JIRA time reports

--- a/exportimportconfig-sample.py
+++ b/exportimportconfig-sample.py
@@ -74,3 +74,7 @@ STATUS_TRANSITIONS = {
 ADD_COMMENT_TO_OLD_ISSUE = True
 
 CUSTOM_FIELD = ('customfield_11086', {'value': 'Custom value'})
+
+#NO_AUTO_CREATE_EPICS = True
+#NO_AUTO_CREATE_SUBTASKS = True
+


### PR DESCRIPTION
Since Jira automatically assigns ticket IDs in the order of their creation, it is not easily possible to perserve the IDs from the source Jira project in the target Jira project.

The only solution is to add them in exactly the same order as they have been added to the source system. Since ask-jira creates EPICs and Subtasks on demand, this would break this order.

This pull request introduces two configuration options NO_AUTO_CREATE_EPICS and NO_AUTO_CREATE_SUBTASKS. Setting both to "true" disables automatic creation of issues and thus issues are added to the target system in the same order they come from the filter.

For details and known limitation, see the README change.

I've performed one Jira project migration so far and it successfully preserved the IDs as expected.
