### PR TITLE
transitions now work with partial config

### DIFF
--- a/lib/export_import.py
+++ b/lib/export_import.py
@@ -221,7 +221,7 @@ def _set_epic_link(dest_issue, source_issue, conf, source_jira, dest_jira):
 
 def _set_status(dest_issue, source_issue, conf, dest_jira):
     # Do nothing if status transitions are disabled.
-    if not conf.STATUS_TRANSITIONS:
+    if not (conf.STATUS_TRANSITIONS or conf.STATUS_TRANSITIONS_ISSUETYPE):
         return
 
     issue_type = dest_issue.fields.issuetype.name
@@ -237,7 +237,7 @@ def _set_status(dest_issue, source_issue, conf, dest_jira):
     if not transition_map:
         transition_map = conf.STATUS_TRANSITIONS
 
-    transitions = transition_map[status_name]
+    transitions = transition_map.get(status_name,None)
     if not transitions:
         return
     # Allow single string and WithResolution values by converting them to a tuple.


### PR DESCRIPTION
No change in documented behaviour, but allows partial config, if not interested in fully mapping everything.

* Fixed if, won't fail if transition is not found, but continues as originally planned (leaves issue open)
* Requires either STATUS_TRANSITIONS or STATUS_TRANSITIONS_ISSUETYPE or both.


